### PR TITLE
Fix parcel-plugin-url-loader repository metadata

### DIFF
--- a/packages/parcel-plugin-url-loader/package.json
+++ b/packages/parcel-plugin-url-loader/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:fansenze/parcel-plugin-url-loader.git"
+    "url": "git+https://github.com/fansenze/parcel-transformer-url-loader.git",
+    "directory": "packages/parcel-plugin-url-loader"
   },
   "keywords": [
     "parcel",


### PR DESCRIPTION
## Summary
- update the `parcel-plugin-url-loader` package repository metadata to point at this public monorepo over HTTPS
- add the package directory so npm/GitHub can resolve the package location correctly

## Verification
- `python3 -m json.tool packages/parcel-plugin-url-loader/package.json`
- `git ls-remote https://github.com/fansenze/parcel-transformer-url-loader.git HEAD`
- `git diff --check`
