### PR TITLE
fix(parcel-plugin-url-loader): use public https repository metadata

### DIFF
--- a/packages/parcel-plugin-url-loader/package.json
+++ b/packages/parcel-plugin-url-loader/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:fansenze/parcel-plugin-url-loader.git"
+    "url": "git+https://github.com/fansenze/parcel-transformer-url-loader.git"
   },
   "keywords": [
     "parcel",


### PR DESCRIPTION
Updates `packages/parcel-plugin-url-loader/package.json` `repository.url` from `git+ssh://git@github.com:fansenze/parcel-plugin-url-loader.git` to `git+https://github.com/fansenze/parcel-transformer-url-loader.git`.

Why: the published `parcel-plugin-url-loader` package lives in the `fansenze/parcel-transformer-url-loader` monorepo; the original SSH URL pointed at a non-existent standalone repo (`fansenze/parcel-plugin-url-loader`). Using HTTPS avoids the SSH credential prompt in non-interactive consumers and matches the actual canonical upstream.

Scope: metadata-only, 1 file, 1 line. No runtime code, dependency, lockfile, entrypoint, version, homepage, or test changes.

Refs charles-openclaw/charles-microbounties#2094